### PR TITLE
Fix initial and maximum memory sizes.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ emconfigure cmake -DCMAKE_CXX_COMPILER="$HOME"/emsdk/emscripten/1.38.25/em++ -DB
 
 emmake make
 em++ -s WASM=1 -g3 -s WASM=1 -s LEGALIZE_JS_FFI=0 -s BINARYEN_TRAP_MODE='clamp' -s ALLOW_MEMORY_GROWTH=1 \
--s EMIT_EMSCRIPTEN_METADATA=1 -s TOTAL_MEMORY=524288000 -O3 --js-library api/wasm/cpp/proxy_wasm_intrinsics.js \
+-s EMIT_EMSCRIPTEN_METADATA=1 -s WASM_MEM_MAX=524288000 -O3 --js-library api/wasm/cpp/proxy_wasm_intrinsics.js \
 libwasm-sd.so api/wasm/cpp/libprotobuf.bc -o wasm-sd.js
 
 wavm-disas wasm-sd.wasm wasm-sd.wat


### PR DESCRIPTION
Previously, the initial memory size was set to 512MB without any maximum,
this commit changes it to 16MB (Emscripten's default) with 512MB maximum.

TOTAL_MEMORY defines initial memory size.
WASM_MEM_MAX defines maximum memory size.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>